### PR TITLE
Swap and NoExcept

### DIFF
--- a/SDL2pp/AudioSpec.cc
+++ b/SDL2pp/AudioSpec.cc
@@ -25,23 +25,20 @@
 
 namespace SDL2pp {
 
-AudioSpec::AudioSpec() {
+AudioSpec::AudioSpec() noexcept {
 	std::fill((char*)this, (char*)this + sizeof(SDL_AudioSpec), 0);
 }
 
-AudioSpec::AudioSpec(int freq, SDL_AudioFormat format, Uint8 channels, Uint16 samples) {
+AudioSpec::AudioSpec(const SDL_AudioSpec& audiospec) noexcept : SDL_AudioSpec(audiospec) {
+}
+
+AudioSpec::AudioSpec(int freq, SDL_AudioFormat format, Uint8 channels, Uint16 samples) noexcept {
 	std::fill((char*)this, (char*)this + sizeof(SDL_AudioSpec), 0);
 	SDL_AudioSpec::freq = freq;
 	SDL_AudioSpec::format = format;
 	SDL_AudioSpec::channels = channels;
 	SDL_AudioSpec::samples = samples;
 }
-
-AudioSpec::~AudioSpec() {
-}
-
-AudioSpec::AudioSpec(AudioSpec&&) = default;
-AudioSpec& AudioSpec::operator=(AudioSpec&&) = default;
 
 void AudioSpec::MergeChanges(const SDL_AudioSpec& obtained) {
 	freq = obtained.freq;

--- a/SDL2pp/AudioSpec.hh
+++ b/SDL2pp/AudioSpec.hh
@@ -47,7 +47,15 @@ public:
 	/// \brief Create empty (invalid) audio format specification
 	///
 	////////////////////////////////////////////////////////////
-	AudioSpec();
+	AudioSpec() noexcept;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Construct an AudioSpec from existing SDL_AudioSpec
+        ///
+        /// \param[in] audiospec Existing SDL_AudioSpec
+        ///
+        ////////////////////////////////////////////////////////////
+        AudioSpec(const SDL_AudioSpec& audiospec) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Create audio format specification with given properties
@@ -60,13 +68,13 @@ public:
 	/// \see http://wiki.libsdl.org/SDL_AudioSpec#Remarks
 	///
 	////////////////////////////////////////////////////////////
-	AudioSpec(int freq, SDL_AudioFormat format, Uint8 channels, Uint16 samples);
+	AudioSpec(int freq, SDL_AudioFormat format, Uint8 channels, Uint16 samples) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Destructor
 	///
 	////////////////////////////////////////////////////////////
-	~AudioSpec();
+	~AudioSpec() = default;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Move constructor
@@ -74,7 +82,7 @@ public:
 	/// \param[in] other SDL2pp::AudioSpec object to move data from
 	///
 	////////////////////////////////////////////////////////////
-	AudioSpec(AudioSpec&& other);
+	AudioSpec(AudioSpec&& other) noexcept = default;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Move assignment operator
@@ -84,7 +92,7 @@ public:
 	/// \returns Reference to self
 	///
 	////////////////////////////////////////////////////////////
-	AudioSpec& operator=(AudioSpec&& other);
+	AudioSpec& operator=(AudioSpec&& other) noexcept = default;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Deleted copy constructor

--- a/SDL2pp/Chunk.cc
+++ b/SDL2pp/Chunk.cc
@@ -25,7 +25,7 @@
 
 namespace SDL2pp {
 
-Chunk::Chunk(Mix_Chunk* chunk) : chunk_(chunk) {
+Chunk::Chunk(Mix_Chunk* chunk) noexcept : chunk_(chunk) {
 }
 
 Chunk::Chunk(const std::string& file) {
@@ -67,6 +67,12 @@ int Chunk::SetVolume(int volume) {
 
 int Chunk::GetVolume() const {
 	return Mix_VolumeChunk(chunk_, -1);
+}
+
+void swap(Chunk& a, Chunk& b) noexcept {
+        using std::swap;
+
+        swap(a.chunk_, b.chunk_);
 }
 
 }

--- a/SDL2pp/Chunk.hh
+++ b/SDL2pp/Chunk.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_CHUNK_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2/SDL_mixer.h>
 
@@ -49,7 +50,7 @@ public:
 	/// \param[in] chunk Existing Mix_Chunk to manage
 	///
 	////////////////////////////////////////////////////////////
-	Chunk(Mix_Chunk* chunk);
+	Chunk(Mix_Chunk* chunk) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Load file for use as a sample
@@ -153,8 +154,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	int GetVolume() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Chunk& a, Chunk& b) noexcept;
 };
 
+}
+
+namespace std {
+	////////////////////////////////////////////////////////////
+	/// \brief std::swap specialization for SDL2pp::Chunk
+	///
+	////////////////////////////////////////////////////////////
+	template<>
+	inline void swap(SDL2pp::Chunk& a, SDL2pp::Chunk& b) noexcept {
+		using std::swap;
+		swap(a, b);
+	}
 }
 
 #endif

--- a/SDL2pp/Font.cc
+++ b/SDL2pp/Font.cc
@@ -19,7 +19,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#include <string>
 #include <vector>
+#include <utility>
 
 #include <SDL2/SDL_ttf.h>
 
@@ -29,8 +31,7 @@
 
 namespace SDL2pp {
 
-Font::Font(TTF_Font* font) {
-	font_ = font;
+Font::Font(TTF_Font* font) noexcept : font_(font) {
 }
 
 Font::Font(const std::string& file, int ptsize, long index) {
@@ -290,6 +291,12 @@ Surface Font::RenderGlyph_Blended(Uint16 ch, SDL_Color fg) {
 	if (surface == nullptr)
 		throw Exception("TTF_RenderGlyph_Blended");
 	return Surface(surface);
+}
+
+void swap(Font& a, Font& b) noexcept {
+	using std::swap;
+
+	swap(a.font_, b.font_);
 }
 
 }

--- a/SDL2pp/Font.hh
+++ b/SDL2pp/Font.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_FONT_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2/SDL_ttf.h>
 
@@ -59,7 +60,7 @@ public:
 	/// \param[in] font Existing TTF_Font to manage
 	///
 	////////////////////////////////////////////////////////////
-	Font(TTF_Font* font);
+	Font(TTF_Font* font) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Loads font from .ttf or .fon file
@@ -97,7 +98,7 @@ public:
 	/// \see https://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf.html#SEC18
 	///
 	////////////////////////////////////////////////////////////
-	virtual ~Font();
+	~Font();
 
 	///@}
 
@@ -824,8 +825,28 @@ public:
 	Surface RenderGlyph_Blended(Uint16 ch, SDL_Color fg);
 
 	///@}
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Font& a, Font& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Font
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Font& a, SDL2pp::Font& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Mixer.cc
+++ b/SDL2pp/Mixer.cc
@@ -19,6 +19,8 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#include <utility>
+
 #include <SDL2pp/Mixer.hh>
 #include <SDL2pp/Chunk.hh>
 #include <SDL2pp/Music.hh>

--- a/SDL2pp/Mixer.hh
+++ b/SDL2pp/Mixer.hh
@@ -22,8 +22,9 @@
 #ifndef SDL2PP_MIXER_HH
 #define SDL2PP_MIXER_HH
 
-#include <functional>
 #include <memory>
+#include <utility>
+#include <functional>
 
 #include <SDL2/SDL_stdinc.h>
 

--- a/SDL2pp/Music.cc
+++ b/SDL2pp/Music.cc
@@ -19,12 +19,14 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#include <utility>
+
 #include <SDL2pp/Music.hh>
 #include <SDL2pp/Exception.hh>
 
 namespace SDL2pp {
 
-Music::Music(Mix_Music* music) : music_(music) {
+Music::Music(Mix_Music* music) noexcept : music_(music) {
 }
 
 Music::Music(const std::string& file) {
@@ -57,6 +59,12 @@ Mix_Music* Music::Get() const {
 
 Mix_MusicType Music::GetType() const {
 	return Mix_GetMusicType(music_);
+}
+
+void swap(Music& a, Music& b) noexcept {
+        using std::swap;
+
+        swap(a.music_, b.music_);
 }
 
 }

--- a/SDL2pp/Music.hh
+++ b/SDL2pp/Music.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_MUSIC_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2/SDL_mixer.h>
 
@@ -47,7 +48,7 @@ public:
 	/// \param[in] music Existing Mix_Music to manage
 	///
 	////////////////////////////////////////////////////////////
-	Music(Mix_Music* music);
+	Music(Mix_Music* music) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Load music file
@@ -118,8 +119,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	Mix_MusicType GetType() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Music& a, Music& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Music
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Music& a, SDL2pp::Music& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Point.hh
+++ b/SDL2pp/Point.hh
@@ -22,6 +22,7 @@
 #ifndef SDL2PP_POINT_HH
 #define SDL2PP_POINT_HH
 
+#include <utility>
 #include <iostream>
 #include <functional>
 
@@ -54,7 +55,7 @@ public:
 	/// Creates a Point(0, 0)
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Point() : SDL_Point{0, 0} {
+	constexpr Point() noexcept : SDL_Point{0, 0} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -63,7 +64,7 @@ public:
 	/// \param[in] point Existing SDL_Point
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Point(const SDL_Point& point) : SDL_Point{point.x, point.y} {
+	constexpr Point(const SDL_Point& point) noexcept : SDL_Point{point.x, point.y} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -73,7 +74,7 @@ public:
 	/// \param[in] y Y coordinate
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Point(int x, int y) : SDL_Point{x, y} {
+	constexpr Point(int x, int y) noexcept : SDL_Point{x, y} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -156,7 +157,7 @@ public:
 	/// \returns New Point representing memberwise negation
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Point operator-() const {
+	constexpr Point operator-() const & {
 		return Point(-x, -y);
 	}
 
@@ -420,6 +421,19 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	Point& Wrap(const Rect& rect);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Point& a, Point& b) noexcept {
+		using std::swap;
+
+		swap(a.x, b.x);
+		swap(a.y, b.y);
+	}
 };
 
 }
@@ -475,7 +489,7 @@ std::ostream& operator<<(std::ostream& stream, const SDL2pp::Point& point);
 namespace std {
 
 ////////////////////////////////////////////////////////////
-/// \brief std::hash specialization for SDL2pp::Rect
+/// \brief std::hash/std::swap specialization for SDL2pp::Point
 ///
 ////////////////////////////////////////////////////////////
 template<>
@@ -494,6 +508,16 @@ struct hash<SDL2pp::Point> {
 		return seed;
 	}
 };
+
+////////////////////////////////////////////////////////////
+/// \brief std::swap specialization for SDL2pp::Point
+///
+////////////////////////////////////////////////////////////
+template<>
+inline void swap(SDL2pp::Point& a, SDL2pp::Point& b) noexcept {
+	using std::swap;
+	swap(a, b);
+}
 
 }
 

--- a/SDL2pp/Point.hh
+++ b/SDL2pp/Point.hh
@@ -489,7 +489,7 @@ std::ostream& operator<<(std::ostream& stream, const SDL2pp::Point& point);
 namespace std {
 
 ////////////////////////////////////////////////////////////
-/// \brief std::hash/std::swap specialization for SDL2pp::Point
+/// \brief std::hash specialization for SDL2pp::Point
 ///
 ////////////////////////////////////////////////////////////
 template<>

--- a/SDL2pp/Point.hh
+++ b/SDL2pp/Point.hh
@@ -157,7 +157,7 @@ public:
 	/// \returns New Point representing memberwise negation
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Point operator-() const & {
+	constexpr Point operator-() const {
 		return Point(-x, -y);
 	}
 

--- a/SDL2pp/Rect.hh
+++ b/SDL2pp/Rect.hh
@@ -22,6 +22,7 @@
 #ifndef SDL2PP_RECT_HH
 #define SDL2PP_RECT_HH
 
+#include <utility>
 #include <functional>
 
 #include <SDL2/SDL_rect.h>
@@ -54,7 +55,7 @@ public:
 	/// Creates a Rect(0, 0, 0, 0)
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Rect() : SDL_Rect{0, 0, 0, 0} {
+	constexpr Rect() noexcept : SDL_Rect{0, 0, 0, 0} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -63,7 +64,7 @@ public:
 	/// \param[in] rect Existing SDL_Rect
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Rect(const SDL_Rect& rect) : SDL_Rect{rect.x, rect.y, rect.w, rect.h} {
+	constexpr Rect(const SDL_Rect& rect) noexcept : SDL_Rect{rect.x, rect.y, rect.w, rect.h} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -73,7 +74,7 @@ public:
 	/// \param[in] size Dimensions of the rectangle
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Rect(const Point& corner, const Point& size) : SDL_Rect{corner.x, corner.y, size.x, size.y} {
+	constexpr Rect(const Point& corner, const Point& size) noexcept : SDL_Rect{corner.x, corner.y, size.x, size.y} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -85,7 +86,7 @@ public:
 	/// \param[in] h Height of the rectangle
 	///
 	////////////////////////////////////////////////////////////
-	constexpr Rect(int x, int y, int w, int h) : SDL_Rect{x, y, w, h} {
+	constexpr Rect(int x, int y, int w, int h) noexcept : SDL_Rect{x, y, w, h} {
 	}
 
 	////////////////////////////////////////////////////////////
@@ -97,7 +98,7 @@ public:
 	/// \param[in] h Height of the rectangle
 	///
 	////////////////////////////////////////////////////////////
-	static constexpr Rect FromCenter(int cx, int cy, int w, int h) {
+	static constexpr Rect FromCenter(int cx, int cy, int w, int h) noexcept {
 		return Rect(cx - w/2, cy - h/2, w, h);
 	}
 
@@ -108,7 +109,7 @@ public:
 	/// \param[in] size Dimensions of the rectangle
 	///
 	////////////////////////////////////////////////////////////
-	static constexpr Rect FromCenter(const Point& center, const Point& size) {
+	static constexpr Rect FromCenter(const Point& center, const Point& size) noexcept {
 		return Rect(center - size / 2, size);
 	}
 
@@ -121,7 +122,7 @@ public:
 	/// \param[in] y2 Y coordinate of the bottom right rectangle corner
 	///
 	////////////////////////////////////////////////////////////
-	static constexpr Rect FromCorners(int x1, int y1, int x2, int y2) {
+	static constexpr Rect FromCorners(int x1, int y1, int x2, int y2) noexcept {
 		return Rect(x1, y1, x2 - x1 + 1, y2 - y1 + 1);
 	}
 
@@ -132,7 +133,7 @@ public:
 	/// \param[in] p2 Coordinates of the bottom right rectangle corner
 	///
 	////////////////////////////////////////////////////////////
-	static constexpr Rect FromCorners(const Point& p1, const Point& p2) {
+	static constexpr Rect FromCorners(const Point& p1, const Point& p2) noexcept {
 		return Rect(p1, p2 - p1 + Point(1, 1));
 	}
 
@@ -581,6 +582,21 @@ public:
 		y -= offset.y;
 		return *this;
 	}
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Rect& a, Rect& b) noexcept {
+		using std::swap;
+
+		swap(a.x, b.x);
+		swap(a.y, b.y);
+		swap(a.w, b.w);
+		swap(a.h, b.h);
+	}
 };
 
 }
@@ -636,7 +652,7 @@ std::ostream& operator<<(std::ostream& stream, const SDL2pp::Rect& rect);
 namespace std {
 
 ////////////////////////////////////////////////////////////
-/// \brief std::hash specialization for SDL2pp::Rect
+/// \brief std::hash/std::swap specialization for SDL2pp::Rect
 ///
 ////////////////////////////////////////////////////////////
 template<>
@@ -657,6 +673,16 @@ struct hash<SDL2pp::Rect> {
 		return seed;
 	}
 };
+
+////////////////////////////////////////////////////////////
+/// \brief std::swap specialization for SDL2pp::Rect
+///
+////////////////////////////////////////////////////////////
+template<>
+inline void swap(SDL2pp::Rect& a, SDL2pp::Rect& b) noexcept {
+	using std::swap;
+	swap(a, b);
+}
 
 }
 

--- a/SDL2pp/Rect.hh
+++ b/SDL2pp/Rect.hh
@@ -652,7 +652,7 @@ std::ostream& operator<<(std::ostream& stream, const SDL2pp::Rect& rect);
 namespace std {
 
 ////////////////////////////////////////////////////////////
-/// \brief std::hash/std::swap specialization for SDL2pp::Rect
+/// \brief std::hash specialization for SDL2pp::Rect
 ///
 ////////////////////////////////////////////////////////////
 template<>

--- a/SDL2pp/Renderer.cc
+++ b/SDL2pp/Renderer.cc
@@ -20,6 +20,7 @@
 */
 
 #include <vector>
+#include <utility>
 
 #include <SDL2/SDL.h>
 
@@ -30,7 +31,7 @@
 
 namespace SDL2pp {
 
-Renderer::Renderer(SDL_Renderer* renderer) : renderer_(renderer) {
+Renderer::Renderer(SDL_Renderer* renderer) noexcept : renderer_(renderer) {
 }
 
 Renderer::Renderer(Window& window, int index, Uint32 flags) {
@@ -433,6 +434,12 @@ int Renderer::GetOutputHeight() const {
 	if (SDL_GetRendererOutputSize(renderer_, nullptr, &h) != 0)
 		throw Exception("SDL_GetRendererOutputSize");
 	return h;
+}
+
+void swap(Renderer& a, Renderer& b) noexcept {
+        using std::swap;
+
+        swap(a.renderer_, b.renderer_);
 }
 
 }

--- a/SDL2pp/Renderer.hh
+++ b/SDL2pp/Renderer.hh
@@ -22,6 +22,8 @@
 #ifndef SDL2PP_RENDERER_HH
 #define SDL2PP_RENDERER_HH
 
+#include <utility>
+
 #include <SDL2/SDL_stdinc.h>
 #include <SDL2/SDL_blendmode.h>
 
@@ -58,7 +60,7 @@ public:
 	/// \param[in] renderer Existing SDL_Renderer to manage
 	///
 	////////////////////////////////////////////////////////////
-	Renderer(SDL_Renderer* renderer);
+	Renderer(SDL_Renderer* renderer) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Create renderer
@@ -82,7 +84,7 @@ public:
 	/// \see http://wiki.libsdl.org/SDL_DestroyRenderer
 	///
 	////////////////////////////////////////////////////////////
-	virtual ~Renderer();
+	~Renderer();
 
 	////////////////////////////////////////////////////////////
 	/// \brief Move constructor
@@ -801,8 +803,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	int GetOutputHeight() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Renderer& a, Renderer& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Renderer
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Renderer& a, SDL2pp::Renderer& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Surface.cc
+++ b/SDL2pp/Surface.cc
@@ -36,7 +36,7 @@
 
 namespace SDL2pp {
 
-Surface::Surface(SDL_Surface* surface) : surface_(surface) {
+Surface::Surface(SDL_Surface* surface) noexcept : surface_(surface) {
 }
 
 Surface::Surface(Uint32 flags, int width, int height, int depth, Uint32 Rmask, Uint32 Gmask, Uint32 Bmask, Uint32 Amask) {
@@ -215,6 +215,12 @@ Point Surface::GetSize() const {
 
 Uint32 Surface::GetFormat() const {
 	return surface_->format->format;
+}
+
+void swap(Surface& a, Surface& b) noexcept {
+        using std::swap;
+
+        swap(a.surface_, b.surface_);
 }
 
 }

--- a/SDL2pp/Surface.hh
+++ b/SDL2pp/Surface.hh
@@ -22,6 +22,8 @@
 #ifndef SDL2PP_SURFACE_HH
 #define SDL2PP_SURFACE_HH
 
+#include <utility>
+
 #include <SDL2/SDL_stdinc.h>
 #include <SDL2/SDL_blendmode.h>
 
@@ -168,7 +170,7 @@ public:
 	/// \param[in] surface Existing SDL_Surface to manage
 	///
 	////////////////////////////////////////////////////////////
-	Surface(SDL_Surface* surface);
+	Surface(SDL_Surface* surface) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Create RGB surface
@@ -551,8 +553,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	Uint32 GetFormat() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Surface& a, Surface& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Surface
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Surface& a, SDL2pp::Surface& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Texture.cc
+++ b/SDL2pp/Texture.cc
@@ -41,7 +41,7 @@
 
 namespace SDL2pp {
 
-Texture::Texture(SDL_Texture* texture) : texture_(texture) {
+Texture::Texture(SDL_Texture* texture) noexcept : texture_(texture) {
 }
 
 Texture::Texture(Renderer& renderer, Uint32 format, int access, int w, int h) {
@@ -193,6 +193,12 @@ SDL_BlendMode Texture::GetBlendMode() const {
 void Texture::GetColorMod(Uint8& r, Uint8& g, Uint8& b) const {
 	if (SDL_GetTextureColorMod(texture_, &r, &g, &b) != 0)
 		throw Exception("SDL_GetTextureColorMod");
+}
+
+void swap(Texture& a, Texture& b) noexcept {
+        using std::swap;
+
+        swap(a.texture_, b.texture_);
 }
 
 }

--- a/SDL2pp/Texture.hh
+++ b/SDL2pp/Texture.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_TEXTURE_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2/SDL_stdinc.h>
 #include <SDL2/SDL_blendmode.h>
@@ -190,7 +191,7 @@ public:
 	/// \param[in] texture Existing SDL_Texture to manage
 	///
 	////////////////////////////////////////////////////////////
-	Texture(SDL_Texture* texture);
+	Texture(SDL_Texture* texture) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Create empty texture
@@ -514,8 +515,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	void GetColorMod(Uint8& r, Uint8& g, Uint8 &b) const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Texture& a, Texture& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Texture
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Texture& a, SDL2pp::Texture& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Wav.cc
+++ b/SDL2pp/Wav.cc
@@ -79,4 +79,13 @@ const AudioSpec& Wav::GetSpec() const {
 	return spec_;
 }
 
+void swap(Wav& a, Wav& b) noexcept {
+        using std::swap;
+
+        swap(a.audio_buffer_, b.audio_buffer_);
+        swap(a.audio_length_, b.audio_length_);
+
+        swap(a.spec_, b.spec_);
+}
+
 }

--- a/SDL2pp/Wav.hh
+++ b/SDL2pp/Wav.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_WAV_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2pp/AudioSpec.hh>
 
@@ -151,8 +152,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	const AudioSpec& GetSpec() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Wav& a, Wav& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Wav
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Wav& a, SDL2pp::Wav& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif

--- a/SDL2pp/Window.cc
+++ b/SDL2pp/Window.cc
@@ -27,7 +27,7 @@
 
 namespace SDL2pp {
 
-Window::Window(SDL_Window* window) : window_(window) {
+Window::Window(SDL_Window* window) noexcept : window_(window) {
 }
 
 Window::Window(const std::string& title, int x, int y, int w, int h, Uint32 flags) {
@@ -240,6 +240,12 @@ Window& Window::SetIcon(const Surface& icon) {
 Window& Window::SetBordered(bool bordered) {
 	SDL_SetWindowBordered(window_, bordered ? SDL_TRUE : SDL_FALSE);
 	return *this;
+}
+
+void swap(Window& a, Window& b) noexcept {
+	using std::swap;
+
+	swap(a.window_, b.window_);
 }
 
 }

--- a/SDL2pp/Window.hh
+++ b/SDL2pp/Window.hh
@@ -23,6 +23,7 @@
 #define SDL2PP_WINDOW_HH
 
 #include <string>
+#include <utility>
 
 #include <SDL2/SDL_stdinc.h>
 #include <SDL2/SDL_video.h>
@@ -73,7 +74,7 @@ public:
 	/// \param[in] window Existing SDL_Window to manage
 	///
 	////////////////////////////////////////////////////////////
-	Window(SDL_Window* window);
+	Window(SDL_Window* window) noexcept;
 
 	////////////////////////////////////////////////////////////
 	/// \brief Create window with specified title and dimensions
@@ -98,7 +99,7 @@ public:
 	/// \see http://wiki.libsdl.org/SDL_DestroyWindow
 	///
 	////////////////////////////////////////////////////////////
-	virtual ~Window();
+	~Window();
 
 	////////////////////////////////////////////////////////////
 	/// \brief Move constructor
@@ -533,8 +534,28 @@ public:
 	///
 	////////////////////////////////////////////////////////////
 	Window& SetBordered(bool bordered = true);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Friend swap function
+        ///
+        /// This class does allow swapping, and this supports ADL
+        ///
+        ////////////////////////////////////////////////////////////
+        friend void swap(Window& a, Window& b) noexcept;
 };
 
+}
+
+namespace std {
+        ////////////////////////////////////////////////////////////
+        /// \brief std::swap specialization for SDL2pp::Window
+        ///
+        ////////////////////////////////////////////////////////////
+        template<>
+	inline void swap(SDL2pp::Window& a, SDL2pp::Window& b) noexcept {
+                using std::swap;
+                swap(a, b);
+        }
 }
 
 #endif


### PR DESCRIPTION
I've added specializations for std::swap, both in the global namespace (as a total specialization, perfectly legal), and as an ADL specialization. As many of the objects are only movable, not copyable, this will increase the speed of swap.

An alternative to this approach would be to wrap the SDL pointers in std::unique_ptr, which would allow the removal of the current customized move constructor/assignment operators, at the cost of having .get() be everywhere.

As well, I've added a few constructors that were omitted when they seemed suitable, and added noexcept to a lot of them; merely copying an SDL pointer won't throw an exception, after all.