### PR TITLE
Ignore manually built .o files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Debug/
 Win32/
 
 # Binaries
+SDL2pp/*.o
 examples/*.exe
 examples/audio_sine
 examples/audio_wav


### PR DESCRIPTION
This will ignore manually built .o files from GCC.