### PR TITLE
fix Mixer examples

### DIFF
--- a/examples/mixer.cc
+++ b/examples/mixer.cc
@@ -33,8 +33,8 @@ using namespace SDL2pp;
 
 int main(int, char*[]) try {
 	SDL sdl(SDL_INIT_AUDIO);
-	SDLMixer mixerlib(MIX_INIT_OGG);
 	Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
+	SDLMixer mixerlib(MIX_INIT_OGG);
 
 	Chunk sound(TESTDATA_DIR "/test.ogg");
 

--- a/examples/mixer_effects.cc
+++ b/examples/mixer_effects.cc
@@ -33,8 +33,8 @@ using namespace SDL2pp;
 
 int main(int, char*[]) try {
 	SDL sdl(SDL_INIT_AUDIO);
-	SDLMixer mixerlib(MIX_INIT_OGG);
 	Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
+	SDLMixer mixerlib(MIX_INIT_OGG);
 
 	Chunk sound(TESTDATA_DIR "/test.ogg");
 

--- a/examples/mixer_music.cc
+++ b/examples/mixer_music.cc
@@ -33,8 +33,8 @@ using namespace SDL2pp;
 
 int main(int, char*[]) try {
 	SDL sdl(SDL_INIT_AUDIO);
+  Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
 	SDLMixer mixerlib(MIX_INIT_OGG);
-	Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
 
 	Music music(TESTDATA_DIR "/test.ogg");
 

--- a/examples/mixer_music.cc
+++ b/examples/mixer_music.cc
@@ -33,7 +33,7 @@ using namespace SDL2pp;
 
 int main(int, char*[]) try {
 	SDL sdl(SDL_INIT_AUDIO);
-  Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
+	Mixer mixer(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, MIX_DEFAULT_CHANNELS, 4096);
 	SDLMixer mixerlib(MIX_INIT_OGG);
 
 	Music music(TESTDATA_DIR "/test.ogg");


### PR DESCRIPTION
I found that examples which use ```SDLMixer``` always fail.

According to [SDL_mixer documentation](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer.html#SEC11), ```Mix_OpenAudio``` must be called before using other functions in SDL_mixer. So constructing ```Mixer``` before ```SDLMixer``` is correct.