### PR TITLE
Fix include for SDL_stdinc.h

### DIFF
--- a/SDL2pp/SDL.hh
+++ b/SDL2pp/SDL.hh
@@ -22,7 +22,7 @@
 #ifndef SDL2PP_SDL_HH
 #define SDL2PP_SDL_HH
 
-#include <SDL_stdinc.h>
+#include <SDL2/SDL_stdinc.h>
 
 #include <SDL2pp/Export.hh>
 


### PR DESCRIPTION
There is an include directive for `<SDL_stdinc.h>` which may not work correctly for all users. The `SDL_stdinc.h` file is found inside the `SDL2` folder of the SDL2 library's installation location. In order for this to work correctly, either:
 1. Many users will have to add `/include/path/SDL2` to their include path, *or*
 2. We update the include directive as `#include <SDL2/SDL_stdinc.h>`.

This PR implements option 2. This is a non-breaking change.

Solves #127. 