### PR TITLE
Surface Blit implementation

### DIFF
--- a/SDL2pp/Surface.cc
+++ b/SDL2pp/Surface.cc
@@ -100,9 +100,8 @@ Surface Surface::Convert(Uint32 pixel_format) {
 	return SDL2pp::Surface(surface);
 }
 
-void Surface::Blit(const Optional<Rect>& srcrect, Surface& dst, const Rect& dstrect) {
-	SDL_Rect tmpdstrect = dstrect; // 4th argument is non-const; does it modify rect?
-	if (SDL_BlitSurface(surface_, srcrect ? &*srcrect : nullptr, dst.Get(), &tmpdstrect) != 0)
+void Surface::Blit(const Optional<Rect>& srcrect, Surface& dst, Optional<Rect>& dstrect) {
+	if (SDL_BlitSurface(surface_, srcrect ? &*srcrect : nullptr, dst.Get(), dstrect ? &*dstrect : nullptr) != 0)
 		throw Exception("SDL_BlitSurface");
 }
 

--- a/SDL2pp/Surface.hh
+++ b/SDL2pp/Surface.hh
@@ -314,14 +314,22 @@ public:
 	///
 	/// \param[in] srcrect Rectangle to be copied, or NullOpt to copy the entire surface
 	/// \param[in] dst Blit target surface
-	/// \param[in] dstrect Rectangle that is copied into
+	/// \param[in] dstrect Rectangle that is copied into. It must be lvalue non-const, but it
+	///                    can be set to NullOpt. After all clipping is performed, final
+	///                    blit rectangle is saved in dstrect if not NullOpt. (SDL3 it is const).\n
+	/// Example:\n
+	/// ```\n
+	/// Optional<Rect> dstrect = NullOpt;\n
+	/// surface.Blit(NullOpt, dst, dstrect);\n
+	/// ```
 	///
 	/// \throws SDL2pp::Exception
 	///
 	/// \see http://wiki.libsdl.org/SDL_BlitSurface
+	/// \see https://wiki.libsdl.org/SDL2/SDL_BlitSurface
 	///
 	////////////////////////////////////////////////////////////
-	void Blit(const Optional<Rect>& srcrect, Surface& dst, const Rect& dstrect);
+	void Blit(const Optional<Rect>& srcrect, Surface& dst, Optional<Rect>& dstrect);
 
 	////////////////////////////////////////////////////////////
 	/// \brief Scaled surface copy to a destination surface


### PR DESCRIPTION
In SDL2 SDL_BlitSurface dstrect can be NULL, and it gets updated with the final blit rectangle after all clipping. SDL3 it is const.